### PR TITLE
Create Multi-Stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/target
+**/node_modules
+**/.git
+**/.idea
+**/*.iml
+**/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Stage 1: Builder
+FROM maven:3.8-openjdk-8 AS builder
+
+WORKDIR /app
+
+# Copy the pom.xml and download dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copy the source code and build the application
+COPY src ./src
+RUN mvn package -DskipTests -B
+
+# Stage 2: Runtime
+FROM openjdk:8-jre-slim
+
+# Create appuser and install curl
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -ms /bin/bash appuser
+
+WORKDIR /app
+
+# Copy the JAR file from the builder stage
+COPY --from=builder /app/target/sample-spring-boot-app-backstage-1.0-SNAPSHOT.jar /app/app.jar
+
+# Change ownership
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER appuser
+
+# Expose the application port
+EXPOSE 8080
+
+# Healthcheck
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
+
+# Set the entry point
+CMD ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
### Analysis

1. **Language and Version**: The application is a Java-based Spring Boot application, as indicated by the `pom.xml` file. The Java version specified is 21.
2. **Packaging Type**: The application is packaged as a JAR file, as it uses the `spring-boot-maven-plugin` which typically packages Spring Boot applications as executable JARs【6:13†source】.
3. **Dependencies**: Key dependencies include Spring Boot Starter Web, Spring Boot Starter Actuator, and Springdoc OpenAPI Starter WebMVC UI【6:13†source】.
4. **Runtime Requirements**: The application will require Java 21 at runtime. The default port for Spring Boot applications is 8080, which should be exposed.

### Dockerfile Generation

Based on the analysis, the application is a Spring Boot JAR application. Below is the multi-stage Dockerfile following the specified rules:

```dockerfile
# Stage 1: Builder
FROM maven:3.8-openjdk-8 AS builder

WORKDIR /app

# Copy the pom.xml and download dependencies
COPY pom.xml .
RUN mvn dependency:go-offline -B

# Copy the source code and build the application
COPY src ./src
RUN mvn package -DskipTests -B

# Stage 2: Runtime
FROM openjdk:8-jre-slim

# Create appuser and install curl
RUN apt-get update && \
    apt-get install -y --no-install-recommends curl && \
    rm -rf /var/lib/apt/lists/* && \
    useradd -ms /bin/bash appuser

WORKDIR /app

# Copy the JAR file from the builder stage
COPY --from=builder /app/target/sample-spring-boot-app-backstage-1.0-SNAPSHOT.jar /app/app.jar

# Change ownership
RUN chown -R appuser:appuser /app

# Switch to non-root user
USER appuser

# Expose the application port
EXPOSE 8080

# Healthcheck
HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -f http://localhost:8080/ || exit 1

# Set the entry point
CMD ["java", "-jar", "/app/app.jar"]
```

### .dockerignore

Create a `.dockerignore` file to optimize the Docker build context:

```
**/target
**/node_modules
**/.git
**/.idea
**/*.iml
**/*.log
```

This Dockerfile and `.dockerignore` are designed to ensure efficient and secure builds, following best practices for a production-ready environment.